### PR TITLE
Add relative submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "snax-mlir"]
 	path = snax-mlir
-	url = https://github.com/KULeuven-MICAS/snax-mlir.git
+	url = ../snax-mlir.git
 [submodule "zigzag"]
 	path = zigzag
-	url = https://github.com/KULeuven-MICAS/zigzag.git
+	url = ../zigzag.git
 [submodule "snax_cluster"]
 	path = snax_cluster
-	url = https://github.com/KULeuven-MICAS/snax_cluster.git
+	url = ../snax_cluster.git


### PR DESCRIPTION
This PR introduces relative paths for submodules.

This is to prevent repositories being cloned with https if you prefer an ssh clone.


### `git clone git@github.com:kuleuven-micas/naxirzag`

If now, you clone the main repo with ssh, all other dependencies will also be cloned with ssh.

```
❯  git submodule update --init --recursive

Submodule 'snax-mlir' (git@github.com:kuleuven-micas/snax-mlir.git) registered for path 'snax-mlir'
Submodule 'snax_cluster' (git@github.com:kuleuven-micas/snax_cluster.git) registered for path 'snax_cluster'
Submodule 'zigzag' (git@github.com:kuleuven-micas/zigzag.git) registered for path 'zigzag'
Cloning into '/home/josse/phd/brol/naxirzag/snax-mlir'...
Cloning into '/home/josse/phd/brol/naxirzag/snax_cluster'...
Cloning into '/home/josse/phd/brol/naxirzag/zigzag'...
Submodule path 'snax-mlir': checked out '0634db2178e09632c5ee3eaaee23d34d9d81171e'
Submodule path 'snax_cluster': checked out '75b9cf0ee2800da6c81cd6a5e82dea84b80f43d0'
Submodule 'sw/deps/printf' (https://github.com/mpaland/printf.git) registered for path 'snax_cluster/sw/deps/printf'
Submodule 'sw/deps/riscv-opcodes' (https://github.com/pulp-platform/riscv-opcodes.git) registered for path 'snax_cluster/sw/deps/riscv-opcodes'
Cloning into '/home/josse/phd/brol/naxirzag/snax_cluster/sw/deps/printf'...
Cloning into '/home/josse/phd/brol/naxirzag/snax_cluster/sw/deps/riscv-opcodes'...
Submodule path 'snax_cluster/sw/deps/printf': checked out 'd3b984684bb8a8bdc48cc7a1abecb93ce59bbe3e'
Submodule path 'snax_cluster/sw/deps/riscv-opcodes': checked out '94caf0e0fefff1009ba144bccb6d8f7d425ea2f5'
Submodule path 'zigzag': checked out '157cf3980e1760805ad7134b3dfa58a66ef7f453'
```


### `git clone https://github.com/kuleuven-micas/naxirzag`

If you are a public user, and prefer https, everything gets checked out over https:

```
❯  git submodule update --init --recursive


Submodule 'snax-mlir' (https://github.com/kuleuven-micas/snax-mlir.git) registered for path 'snax-mlir'
Submodule 'snax_cluster' (https://github.com/kuleuven-micas/snax_cluster.git) registered for path 'snax_cluster'
Submodule 'zigzag' (https://github.com/kuleuven-micas/zigzag.git) registered for path 'zigzag'
Cloning into '/home/josse/phd/brol/naxirzag/snax-mlir'...
Cloning into '/home/josse/phd/brol/naxirzag/snax_cluster'...
Cloning into '/home/josse/phd/brol/naxirzag/zigzag'...
Submodule path 'snax-mlir': checked out '0634db2178e09632c5ee3eaaee23d34d9d81171e'
Submodule path 'snax_cluster': checked out '75b9cf0ee2800da6c81cd6a5e82dea84b80f43d0'
Submodule 'sw/deps/printf' (https://github.com/mpaland/printf.git) registered for path 'snax_cluster/sw/deps/printf'
Submodule 'sw/deps/riscv-opcodes' (https://github.com/pulp-platform/riscv-opcodes.git) registered for path 'snax_cluster/sw/deps/riscv-opcodes'
Cloning into '/home/josse/phd/brol/naxirzag/snax_cluster/sw/deps/printf'...
Cloning into '/home/josse/phd/brol/naxirzag/snax_cluster/sw/deps/riscv-opcodes'...
Submodule path 'snax_cluster/sw/deps/printf': checked out 'd3b984684bb8a8bdc48cc7a1abecb93ce59bbe3e'
Submodule path 'snax_cluster/sw/deps/riscv-opcodes': checked out '94caf0e0fefff1009ba144bccb6d8f7d425ea2f5'
Submodule path 'zigzag': checked out '157cf3980e1760805ad7134b3dfa58a66ef7f453'

```
